### PR TITLE
Add StableHost staging domains

### DIFF
--- a/website.tf
+++ b/website.tf
@@ -13,3 +13,19 @@ resource "aws_route53_record" "website_www" {
   ttl     = 21600
   records = ["intimitrons.ca."]
 }
+
+resource "aws_route53_record" "website_primary_staging" {
+  zone_id = data.terraform_remote_state.dns.outputs.zone_id
+  name    = "staging"
+  type    = "A"
+  ttl     = 300
+  records = ["198.20.92.28"]
+}
+
+resource "aws_route53_record" "website_www_staging" {
+  zone_id = data.terraform_remote_state.dns.outputs.zone_id
+  name    = "www.staging"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["staging.intimitrons.ca."]
+}


### PR DESCRIPTION
These are for interim deployment automation until we re-architect the site for AWS