### PR TITLE
Update to AWS Provider v3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.0"
   region  = "us-west-2"
 }
 

--- a/website.tf
+++ b/website.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "website_www" {
   name    = "www"
   type    = "CNAME"
   ttl     = 86400
-  records = ["intimitrons.ca."]
+  records = ["intimitrons.ca"]
 }
 
 resource "aws_route53_record" "website_primary_staging" {
@@ -27,5 +27,5 @@ resource "aws_route53_record" "website_www_staging" {
   name    = "www.staging"
   type    = "CNAME"
   ttl     = 86400
-  records = ["staging.intimitrons.ca."]
+  records = ["staging.intimitrons.ca"]
 }


### PR DESCRIPTION
Resolves #10

Also remove trailing dots, Route53 doesn't need them

> The fully qualified domain name (for example, www.example.com) that you want Route 53 to return in response to DNS queries for this record. A trailing dot is optional; Route 53 assumes that the domain name is fully qualified. This means that Route 53 treats www.example.com (without a trailing dot) and www.example.com. (with a trailing dot) as identical.

https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-basic.html#rrsets-values-basic-value